### PR TITLE
Fix SUB option handling

### DIFF
--- a/scripts/rank_combination.py
+++ b/scripts/rank_combination.py
@@ -34,7 +34,7 @@ def restoreStub(combination, dict_data):
     
     if "SUB" in synopsis and "SUB" in dict_data["options"]:
         sub_command = random.choice(dict_data["options"]["SUB"])
-        stub = synopsis.replace("SUB", sub_command)
+        synopsis = synopsis.replace("SUB", sub_command)
     
     stub = synopsis.replace("OPTIONS", new_combination)
     return stub


### PR DESCRIPTION
The "SUB" command options are never replaced
because the updated `stub` variable (in line 37) is immediately updated in line 39 with another value.